### PR TITLE
Release prep for 4.0.0: sandbox canary + base pin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,8 @@ on:
     branches: [main]
 
 jobs:
+  # Required gate. Renders with the sandbox off (DISABLE_CHROMIUM_SANDBOX=true) — the path we support
+  # on hosts that restrict unprivileged user namespaces, which is where the sandbox can't run.
   test:
     runs-on: ubuntu-latest
     steps:
@@ -21,8 +23,6 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      # GitHub's Ubuntu runners restrict the unprivileged user namespaces Chromium's sandbox needs,
-      # so the suite runs in no-sandbox mode. See the README Security section for host requirements.
       - name: Run tests
         run: npm test
         env:
@@ -33,5 +33,41 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: test-render-output
+          path: tests/__output__/
+          if-no-files-found: ignore
+
+  # Non-blocking canary. Renders with Chromium's sandbox ON under CAP_SYS_ADMIN — the posture consumers
+  # on restricted-userns hosts historically relied on. Chromium 149+ can no longer build its namespace
+  # sandbox there (144 could), so a base-image bump that crosses that line breaks those consumers while
+  # the no-sandbox gate above stays green. This job makes that breakage visible on the PR instead of
+  # only in production. It is expected to be red until such consumers move to DISABLE_CHROMIUM_SANDBOX=true
+  # or enable unprivileged user namespaces on their hosts; continue-on-error keeps it from blocking merges.
+  # Do NOT relax userns here (e.g. sysctl apparmor_restrict_unprivileged_userns=0) — that masks the very
+  # failure this canary exists to surface.
+  sandbox-canary:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 26
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test
+        env:
+          RUN_MODE: sys-admin
+
+      - name: Upload rendered output on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-render-output-sys-admin
           path: tests/__output__/
           if-no-files-found: ignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:26-alpine
+FROM node:24-alpine
 
 # Installs Chromium package.
 RUN apk add --no-cache \


### PR DESCRIPTION
Prep for cutting **4.0.0** — a correctly-versioned re-release of the breaking changes that shipped as 3.1.2 (runtime contract change: `ENTRYPOINT` replaces `CMD`, and modern Chromium can't sandbox under `CAP_SYS_ADMIN` on restricted-userns hosts).

## Changes
- **`ci`** — split the test workflow into a required `no-sandbox` job (the supported render path) and a **non-blocking** `sandbox-canary` job. The canary runs `RUN_MODE=sys-admin` with the runner's default (restricted) user namespaces — the exact posture consumers deploy with — so a Chromium bump that breaks the sandbox shows up on the PR instead of only in production. It does **not** relax userns, which would mask the failure.
  - Expected to be **red until consumers move to `DISABLE_CHROMIUM_SANDBOX=true`** or enable userns on their hosts; `continue-on-error` keeps it from blocking merges.
- **`build`** — pin base image to `node:24-alpine`. Cosmetic (both 24 and 26 currently resolve to Chromium 150); Dependabot will re-propose 26 and the canary will gate it.

## Why this matters
3.1.2 broke projects (relies on `SYS_ADMIN`) because Chromium jumped 144→149; CI only ever exercised `no-sandbox`, so it went green. This canary closes that gap.

## Follow-up (not in this PR)
- Tag `v4.0.0` after merge; publish GitHub Release with the upgrade guide.
- Drop the 3.1.2 tag + Release (keep the ghcr image).
- Migrate projects Helm to `v4.0.0` + `DISABLE_CHROMIUM_SANDBOX=true` + drop `SYS_ADMIN`.